### PR TITLE
make JSON logging a configurable option via an environment variable

### DIFF
--- a/app.py
+++ b/app.py
@@ -86,11 +86,7 @@ class Feedback(Base):
 
 app = Flask(__name__)
 
-formatter = json_log_formatter.JSONFormatter()
-json_handler = logging.StreamHandler()
-json_handler.setFormatter(formatter)
 logger = logging.getLogger()
-logger.addHandler(json_handler)
 logger.setLevel(logging.INFO)
 
 
@@ -100,6 +96,15 @@ if os.path.exists(os.path.join(os.getcwd(), "config.py")):
     app.config.from_pyfile(os.path.join(os.getcwd(), "config.py"))
 else:
     app.config.from_pyfile(os.path.join(os.getcwd(), "config.env.py"))
+
+
+if app.config["JSON_LOGS"] is True:
+    formatter = json_log_formatter.JSONFormatter()
+    json_handler = logging.StreamHandler()
+    json_handler.setFormatter(formatter)
+    logger.addHandler(json_handler)
+
+logging.info("Starting up...")
 
 git_cmd = ['git', 'rev-parse', '--short', 'HEAD']
 app.config["GIT_REVISION"] = subprocess.check_output(git_cmd).decode('utf-8').rstrip()

--- a/config.env.py
+++ b/config.env.py
@@ -6,6 +6,8 @@ DBPWD =  os.getenv("DBPWD", default="")
 DBHOST = os.getenv("DBHOST", default="postgres.csh.rit.edu")
 DBPORT = os.getenv("DBPORT", default="5432")
 
+JSON_LOGS = os.getenv("JSON_LOGS", default=True)
+
 S3_URL = os.getenv("S3_URL", default="s3.csh.rit.edu")
 S3_KEY = os.getenv("S3_KEY", default="")
 S3_SECRET = os.getenv("S3_SECRET", default="")


### PR DESCRIPTION
While using tunnelvision locally, I found the json format logs to be a little annoying and added a feature to let me disable them selectively.


I left the default value at True so this should have no impact on existing tunnelvision deployments